### PR TITLE
feat: support extends using node_modules resolution logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function loadConfig(filename) {
   const configJson = require(filename)
   if (configJson.extends) {
     let baseConfigFilename;
-    if (configJson.extends.startsWith('./') || configJson.extends.startsWith('../')) {
+    if (configJson.extends.startsWith('.')) {
       baseConfigFilename = path.join(path.dirname(filename), configJson.extends)
     } else {
       baseConfigFilename = require.resolve(configJson.extends)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,12 @@ function loadConfig(filename) {
   debug('reading config file %s', filename)
   const configJson = require(filename)
   if (configJson.extends) {
-    const baseConfigFilename = require.resolve(configJson.extends)
+    let baseConfigFilename;
+    if (configJson.extends.startsWith('./') || configJson.extends.startsWith('../')) {
+      baseConfigFilename = path.join(path.dirname(filename), configJson.extends)
+    } else {
+      baseConfigFilename = require.resolve(configJson.extends)
+    }
     debug('config file extends %s', baseConfigFilename)
     const baseConfig = loadConfig(baseConfigFilename)
     debug('merging %s with %s', baseConfigFilename, filename)

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ function loadConfig(filename) {
   debug('reading config file %s', filename)
   const configJson = require(filename)
   if (configJson.extends) {
-    const baseConfigFilename = path.join(
-      path.dirname(filename), configJson.extends)
+    const baseConfigFilename = require.resolve(configJson.extends)
     debug('config file extends %s', baseConfigFilename)
     const baseConfig = loadConfig(baseConfigFilename)
     debug('merging %s with %s', baseConfigFilename, filename)


### PR DESCRIPTION
support the `extends` syntax for packages by using [require.resolve ](https://nodejs.org/api/modules.html#modules_require_resolve_request_options).
this allows config to extend from external config located in libraries published in the node_modules directory.

without this change, attempting to use a package such as:
```
    extends: "@some-lib/cypress-config"
```
does not behave as expected as the library is incorrectly appended to the current path.
        
this is similar/parity with other configuration systems such as [eslint](https://eslint.org/docs/developer-guide/shareable-configs#using-a-shareable-config) (or [tslint](https://palantir.github.io/tslint/usage/configuration/)) that support the `extends` keyword